### PR TITLE
タスク管理のPowerPoint出力機能を改善

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,6 +80,65 @@
                             </div>
                         </div>
                     </div>
+
+                    <!-- 詳細可視化セクション -->
+                    <div class="visualization-section">
+                        <!-- 部署別進捗状況テーブル -->
+                        <div class="data-visualization">
+                            <h4><i class="fas fa-table"></i> 部署別進捗状況</h4>
+                            <div class="table-container">
+                                <table id="departmentProgressTable1" class="data-table">
+                                    <thead>
+                                        <tr>
+                                            <th>部署</th>
+                                            <th>リリース済み</th>
+                                            <th>リリース準備中</th>
+                                            <th>開発中</th>
+                                            <th>開発対象</th>
+                                            <th>検討</th>
+                                            <th>中断</th>
+                                            <th>保留</th>
+                                            <th>開発検討</th>
+                                            <th>総計</th>
+                                            <th>完了率</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody></tbody>
+                                </table>
+                            </div>
+                        </div>
+
+                        <!-- 進捗カテゴリ統計 -->
+                        <div class="data-visualization">
+                            <h4><i class="fas fa-chart-pie"></i> 進捗カテゴリ別統計</h4>
+                            <div id="progressCategoryStats1" class="stats-grid"></div>
+                        </div>
+
+                        <!-- 処理済みデータプレビュー -->
+                        <div class="data-visualization">
+                            <h4><i class="fas fa-list"></i> 処理済みデータプレビュー</h4>
+                            <div class="data-controls">
+                                <input type="text" id="dataFilter1" placeholder="データを検索..." class="filter-input">
+                                <select id="categoryFilter1" class="filter-select">
+                                    <option value="">すべてのカテゴリ</option>
+                                </select>
+                            </div>
+                            <div class="table-container">
+                                <table id="processedDataTable1" class="data-table">
+                                    <thead></thead>
+                                    <tbody></tbody>
+                                </table>
+                            </div>
+                            <div class="table-pagination">
+                                <span id="dataCount1">データ件数: 0</span>
+                                <div class="pagination-controls">
+                                    <button id="prevPage1" onclick="changePage(1, -1)">前へ</button>
+                                    <span id="pageInfo1">1 / 1</span>
+                                    <button id="nextPage1" onclick="changePage(1, 1)">次へ</button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                     
                     <!-- エクスポートボタン -->
                     <div class="export-section">
@@ -139,10 +198,48 @@
                         </div>
                     </div>
 
-                    <!-- 進捗分類結果 -->
-                    <div class="classification-result">
-                        <h4>進捗状況分類結果</h4>
-                        <div id="classificationSummary2"></div>
+                    <!-- 詳細可視化セクション -->
+                    <div class="visualization-section">
+                        <!-- 進捗分類結果 -->
+                        <div class="data-visualization">
+                            <h4><i class="fas fa-chart-bar"></i> 進捗状況分類結果</h4>
+                            <div id="classificationSummary2" class="classification-summary"></div>
+                            <div id="classificationChart2" class="classification-chart"></div>
+                        </div>
+
+                        <!-- タスクデータテーブル -->
+                        <div class="data-visualization">
+                            <h4><i class="fas fa-table"></i> 処理済みタスクデータ</h4>
+                            <div class="data-controls">
+                                <input type="text" id="taskFilter2" placeholder="タスクを検索..." class="filter-input">
+                                <select id="taskStatusFilter2" class="filter-select">
+                                    <option value="">すべての進捗状況</option>
+                                </select>
+                                <select id="taskCategoryFilter2" class="filter-select">
+                                    <option value="">すべての部署</option>
+                                </select>
+                            </div>
+                            <div class="table-container">
+                                <table id="taskDataTable2" class="data-table">
+                                    <thead></thead>
+                                    <tbody></tbody>
+                                </table>
+                            </div>
+                            <div class="table-pagination">
+                                <span id="taskCount2">タスク件数: 0</span>
+                                <div class="pagination-controls">
+                                    <button id="prevTaskPage2" onclick="changePage(2, -1)">前へ</button>
+                                    <span id="taskPageInfo2">1 / 1</span>
+                                    <button id="nextTaskPage2" onclick="changePage(2, 1)">次へ</button>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- 統計情報 -->
+                        <div class="data-visualization">
+                            <h4><i class="fas fa-chart-pie"></i> タスク統計情報</h4>
+                            <div id="taskStats2" class="stats-grid"></div>
+                        </div>
                     </div>
                     
                     <!-- エクスポートボタン -->

--- a/styles.css
+++ b/styles.css
@@ -772,6 +772,340 @@ tr:hover {
     margin-top: 8px;
 }
 
+/* メンバープレビュー関連スタイル */
+.member-preview {
+    margin-top: 20px;
+}
+
+.member-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    gap: 15px;
+    margin-top: 15px;
+}
+
+.member-card {
+    background: #f8f9fa;
+    border: 1px solid #e9ecef;
+    border-radius: 8px;
+    padding: 15px;
+    transition: transform 0.2s ease;
+}
+
+.member-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+}
+
+.member-card .furigana {
+    font-size: 0.8rem;
+    color: #666;
+    margin-bottom: 5px;
+}
+
+.member-card .name {
+    font-weight: bold;
+    font-size: 1.1rem;
+    margin-bottom: 5px;
+}
+
+.member-card .details {
+    color: #666;
+    font-size: 0.9rem;
+    margin-bottom: 10px;
+}
+
+.member-card .description {
+    font-size: 0.9rem;
+    line-height: 1.4;
+    margin-bottom: 10px;
+}
+
+.member-card .start-month {
+    background: #4472C4;
+    color: white;
+    padding: 3px 8px;
+    border-radius: 12px;
+    font-size: 0.8rem;
+    display: inline-block;
+}
+
+/* === 新しい可視化要素のスタイル === */
+
+/* 可視化セクション全体 */
+.visualization-section {
+    margin-top: 30px;
+    display: flex;
+    flex-direction: column;
+    gap: 30px;
+}
+
+/* 各可視化ブロック */
+.data-visualization {
+    background: #ffffff;
+    border: 1px solid #e3e6ea;
+    border-radius: 12px;
+    padding: 25px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.05);
+}
+
+.data-visualization h4 {
+    margin: 0 0 20px 0;
+    color: #2c3e50;
+    font-size: 1.2rem;
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.data-visualization h4 i {
+    color: #3498db;
+    font-size: 1.1rem;
+}
+
+/* データテーブルのスタイル */
+.table-container {
+    width: 100%;
+    overflow-x: auto;
+    border-radius: 8px;
+    border: 1px solid #e3e6ea;
+    margin-top: 15px;
+}
+
+.data-table {
+    width: 100%;
+    border-collapse: collapse;
+    background: #ffffff;
+    font-size: 0.9rem;
+}
+
+.data-table thead {
+    background: #ffffff;
+    position: sticky;
+    top: 0;
+    border-bottom: 2px solid #dee2e6;
+}
+
+.data-table thead th {
+    padding: 15px 12px;
+    text-align: left;
+    font-weight: 600;
+    color: #2c3e50;
+    background: #ffffff;
+    border-bottom: 2px solid #dee2e6;
+    white-space: nowrap;
+}
+
+.data-table tbody td {
+    padding: 12px;
+    border-bottom: 1px solid #f1f3f4;
+    vertical-align: top;
+}
+
+.data-table tbody tr:hover {
+    background-color: #f8f9fa;
+}
+
+.data-table tbody tr:nth-child(even) {
+    background-color: #fdfdfd;
+}
+
+/* 統計グリッドのスタイル */
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 15px;
+    margin-top: 15px;
+}
+
+.stat-card {
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
+    padding: 20px;
+    border-radius: 10px;
+    text-align: center;
+    box-shadow: 0 4px 15px rgba(0,0,0,0.1);
+    transition: transform 0.2s ease;
+}
+
+.stat-card:hover {
+    transform: translateY(-5px);
+}
+
+.stat-card .stat-value {
+    font-size: 2rem;
+    font-weight: bold;
+    margin-bottom: 5px;
+}
+
+.stat-card .stat-label {
+    font-size: 0.9rem;
+    opacity: 0.9;
+}
+
+.stat-card.stat-released {
+    background: linear-gradient(135deg, #11998e 0%, #38ef7d 100%);
+}
+
+.stat-card.stat-in-progress {
+    background: linear-gradient(135deg, #ffecd2 0%, #fcb69f 100%);
+    color: #333;
+}
+
+.stat-card.stat-pending {
+    background: linear-gradient(135deg, #a8edea 0%, #fed6e3 100%);
+    color: #333;
+}
+
+.stat-card.stat-suspended {
+    background: linear-gradient(135deg, #ff9a9e 0%, #fecfef 100%);
+    color: #333;
+}
+
+/* 分類結果のスタイル */
+.classification-summary {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 15px;
+    margin: 15px 0;
+}
+
+.classification-item {
+    background: #f8f9fa;
+    padding: 15px;
+    border-radius: 8px;
+    text-align: center;
+    border-left: 4px solid #3498db;
+}
+
+.classification-item .label {
+    display: block;
+    font-size: 0.9rem;
+    color: #666;
+    margin-bottom: 5px;
+}
+
+.classification-item .value {
+    display: block;
+    font-size: 1.5rem;
+    font-weight: bold;
+    color: #2c3e50;
+}
+
+/* 分類チャート（シンプルなバー表示） */
+.classification-chart {
+    margin-top: 20px;
+}
+
+.chart-bar {
+    display: flex;
+    align-items: center;
+    margin-bottom: 10px;
+    background: #f8f9fa;
+    border-radius: 8px;
+    padding: 10px;
+}
+
+.chart-bar-label {
+    width: 120px;
+    font-size: 0.9rem;
+    font-weight: 500;
+    color: #2c3e50;
+}
+
+.chart-bar-visual {
+    flex: 1;
+    height: 20px;
+    background: #e9ecef;
+    border-radius: 10px;
+    margin: 0 15px;
+    overflow: hidden;
+    position: relative;
+}
+
+.chart-bar-fill {
+    height: 100%;
+    background: linear-gradient(90deg, #3498db, #2980b9);
+    border-radius: 10px;
+    transition: width 0.8s ease;
+}
+
+.chart-bar-value {
+    font-size: 0.9rem;
+    font-weight: bold;
+    color: #2c3e50;
+    min-width: 40px;
+}
+
+/* フィルターコントロール */
+.data-controls {
+    display: flex;
+    gap: 15px;
+    margin-bottom: 20px;
+    flex-wrap: wrap;
+}
+
+.filter-input, .filter-select {
+    padding: 10px 15px;
+    border: 1px solid #ddd;
+    border-radius: 6px;
+    font-size: 0.9rem;
+    background: #ffffff;
+    transition: border-color 0.2s ease;
+}
+
+.filter-input:focus, .filter-select:focus {
+    outline: none;
+    border-color: #3498db;
+    box-shadow: 0 0 0 3px rgba(52, 152, 219, 0.1);
+}
+
+.filter-input {
+    flex: 1;
+    min-width: 200px;
+}
+
+.filter-select {
+    min-width: 150px;
+}
+
+/* ページネーション */
+.table-pagination {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: 20px;
+    padding: 15px 0;
+    border-top: 1px solid #e3e6ea;
+}
+
+.pagination-controls {
+    display: flex;
+    align-items: center;
+    gap: 15px;
+}
+
+.pagination-controls button {
+    padding: 8px 16px;
+    border: 1px solid #ddd;
+    background: #ffffff;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 0.9rem;
+    transition: all 0.2s ease;
+}
+
+.pagination-controls button:hover:not(:disabled) {
+    background: #f8f9fa;
+    border-color: #3498db;
+}
+
+.pagination-controls button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
 /* レスポンシブ対応 */
 @media (max-width: 768px) {
     .container {
@@ -820,4 +1154,285 @@ tr:hover {
     .member-list {
         grid-template-columns: 1fr;
     }
+
+    .stats-grid {
+        grid-template-columns: 1fr 1fr;
+    }
+    
+    .classification-summary {
+        grid-template-columns: 1fr 1fr;
+    }
+    
+    .data-controls {
+        flex-direction: column;
+    }
+    
+    .filter-input, .filter-select {
+        width: 100%;
+    }
+    
+    .table-pagination {
+        flex-direction: column;
+        gap: 15px;
+    }
+    
+    .pagination-controls {
+        justify-content: center;
+    }
+    
+    .data-table {
+        font-size: 0.8rem;
+    }
+    
+    .data-table thead th,
+    .data-table tbody td {
+        padding: 8px 6px;
+    }
+}
+
+@media (max-width: 480px) {
+    .stats-grid {
+        grid-template-columns: 1fr;
+    }
+    
+    .classification-summary {
+        grid-template-columns: 1fr;
+    }
+    
+    .member-list {
+        grid-template-columns: 1fr;
+    }
+    
+    .data-visualization {
+        padding: 15px;
+    }
+    
+    .chart-bar {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 8px;
+    }
+    
+    .chart-bar-label {
+        width: auto;
+        text-align: center;
+    }
+    
+    .chart-bar-visual {
+        margin: 0;
+    }
+}
+
+/* === 追加の可視化スタイル === */
+
+/* ステータスバッジ */
+.stat-badge {
+    display: inline-block;
+    padding: 4px 8px;
+    border-radius: 12px;
+    font-size: 0.8rem;
+    font-weight: bold;
+    text-align: center;
+    min-width: 30px;
+}
+
+.stat-badge.stat-released {
+    background: #d4edda;
+    color: #155724;
+}
+
+.stat-badge.stat-ready {
+    background: #d1ecf1;
+    color: #0c5460;
+}
+
+.stat-badge.stat-development {
+    background: #fff3cd;
+    color: #856404;
+}
+
+.stat-badge.stat-consideration {
+    background: #e2e3e5;
+    color: #383d41;
+}
+
+.stat-badge.stat-suspended {
+    background: #f8d7da;
+    color: #721c24;
+}
+
+.stat-badge.stat-hold {
+    background: #ffeaa7;
+    color: #6c5ce7;
+}
+
+/* 進捗状況バッジ */
+.status-badge {
+    display: inline-block;
+    padding: 4px 10px;
+    border-radius: 15px;
+    font-size: 0.8rem;
+    font-weight: 500;
+    text-align: center;
+}
+
+.status-badge.status-リリース済み {
+    background: #d4edda;
+    color: #155724;
+}
+
+.status-badge.status-リリース準備 {
+    background: #d1ecf1;
+    color: #0c5460;
+}
+
+.status-badge.status-開発中 {
+    background: #fff3cd;
+    color: #856404;
+}
+
+/* 完了率表示 */
+.completion-rate {
+    font-weight: bold;
+    padding: 4px 8px;
+    border-radius: 8px;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
+    font-size: 0.9rem;
+}
+
+/* 総計行のスタイル */
+.total-row {
+    background-color: #f8f9fa !important;
+    font-weight: bold;
+    border-top: 2px solid #dee2e6;
+}
+
+.total-row td {
+    padding: 15px 12px !important;
+    color: #2c3e50;
+}
+
+/* 統計カードの色分け */
+.stat-card.stat-total {
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+}
+
+.stat-card.stat-processed {
+    background: linear-gradient(135deg, #11998e 0%, #38ef7d 100%);
+}
+
+.stat-card.stat-excluded {
+    background: linear-gradient(135deg, #ff9a9e 0%, #fecfef 100%);
+    color: #333;
+}
+
+.stat-card.stat-rate {
+    background: linear-gradient(135deg, #ffecd2 0%, #fcb69f 100%);
+    color: #333;
+}
+
+.stat-card.stat-intern-cost {
+    background: linear-gradient(135deg, #a8edea 0%, #fed6e3 100%);
+    color: #333;
+}
+
+.stat-card.stat-outsourcing-cost {
+    background: linear-gradient(135deg, #ffd89b 0%, #19547b 100%);
+    color: #fff;
+}
+
+.stat-card.stat-revenue {
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: #fff;
+}
+
+.stat-card.stat-efficiency {
+    background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
+    color: #fff;
+}
+
+/* テーブルホバー効果の強化 */
+.data-table tbody tr:hover {
+    background-color: #e3f2fd !important;
+    transform: translateY(-1px);
+    box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    transition: all 0.2s ease;
+}
+
+/* スクロールバーのカスタマイズ */
+.table-container::-webkit-scrollbar {
+    height: 8px;
+}
+
+.table-container::-webkit-scrollbar-track {
+    background: #f1f1f1;
+    border-radius: 4px;
+}
+
+.table-container::-webkit-scrollbar-thumb {
+    background: #c1c1c1;
+    border-radius: 4px;
+}
+
+.table-container::-webkit-scrollbar-thumb:hover {
+    background: #a8a8a8;
+}
+
+/* アニメーション効果 */
+@keyframes slideIn {
+    from {
+        opacity: 0;
+        transform: translateY(20px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.data-visualization {
+    animation: slideIn 0.5s ease-out;
+}
+
+.stat-card {
+    animation: slideIn 0.6s ease-out;
+}
+
+.chart-bar-fill {
+    animation: fillBar 1.2s ease-out;
+}
+
+@keyframes fillBar {
+    from {
+        width: 0%;
+    }
+    to {
+        width: var(--target-width);
+    }
+}
+
+/* ローディング状態のスタイル */
+.loading-table {
+    opacity: 0.6;
+    pointer-events: none;
+}
+
+.loading-table::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 30px;
+    height: 30px;
+    margin: -15px 0 0 -15px;
+    border: 3px solid #f3f3f3;
+    border-top: 3px solid #3498db;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
 } 


### PR DESCRIPTION
- ページネーション対応: ブラウザの表示と同じ20件ずつの分割でスライド生成
- サマリースライド追加: 処理統計、費用収益統計、進捗状況分類を含む詳細サマリー
- 金額表示の修正: PowerPointでは数値のみ（カンマ区切り）、ブラウザでは円単位を維持
- フィルター対応: ブラウザで絞り込み中のデータのみをPowerPoint出力
- テーブル形式での表データ出力を実装